### PR TITLE
Avoid full restart for purge of old services/watches

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,10 +158,10 @@ it easy to declare in hiera.
 
 ## Removing Service, Check and Watch definitions
 
-Do `ensure => absent` while removing existing service, check and watch
-definitions. This ensures consul will be reloaded via `SIGHUP`. If you have
-`purge_config_dir` set to `true` and simply remove the definition it will cause
-consul to restart.
+These are now placed in a sub-directory and loaded with an additional
+config-dir parameter to the service, so it is now safe to remove these these
+without first doing `ensure => absent`. Note that the migration will trigger
+a restart, due to purging of old files in the root configuration directory.
 
 ## ACL Definitions
 

--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -79,7 +79,7 @@ define consul::check(
 
   $escaped_id = regsubst($id,'\/','_','G')
   File[$consul::config_dir] ->
-  file { "${consul::config_dir}/check_${escaped_id}.json":
+  file { "${consul::config_dir}/extras/check_${escaped_id}.json":
     ensure  => $ensure,
     owner   => $consul::user,
     group   => $consul::group,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -167,7 +167,6 @@ class consul (
   class { 'consul::config':
     config_hash => $config_hash_real,
     purge       => $purge_config_dir,
-    notify      => $notify_service,
   } ->
   class { 'consul::run_service': } ->
   class { 'consul::reload_service': } ->

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -59,7 +59,7 @@ define consul::service(
   }
 
   $escaped_id = regsubst($id,'\/','_','G')
-  file { "${consul::config_dir}/service_${escaped_id}.json":
+  file { "${consul::config_dir}/extras/service_${escaped_id}.json":
     ensure  => $ensure,
     owner   => $consul::user,
     group   => $consul::group,

--- a/manifests/watch.pp
+++ b/manifests/watch.pp
@@ -134,7 +134,7 @@ define consul::watch(
   }
 
   File[$consul::config_dir] ->
-  file { "${consul::config_dir}/watch_${id}.json":
+  file { "${consul::config_dir}/extras/watch_${id}.json":
     ensure  => $ensure,
     owner   => $consul::user,
     group   => $consul::group,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -46,14 +46,22 @@ describe 'consul' do
   end
 
   context 'consul::config should notify consul::run_service' do
-    it { should contain_class('consul::config').that_notifies(['Class[consul::run_service]']) }
+    it { should contain_file('/etc/consul').that_notifies(['Class[consul::run_service]']) }
+  end
+
+  context 'consul::config extras should not notify consul::run_service' do
+    it { should_not contain_file('/etc/consul/extras').that_notifies(['Class[consul::run_service]']) }
+  end
+
+  context 'consul config extras should notify consul::reload_service' do
+    it { should contain_file('/etc/consul/extras').that_notifies(['Class[consul::reload_service]']) }
   end
 
   context 'consul::config should not notify consul::run_service on config change' do
     let(:params) {{
       :restart_on_change => false
     }}
-    it { should_not contain_class('consul::config').that_notifies(['Class[consul::run_service]']) }
+    it { should_not contain_file('/etc/consul').that_notifies(['Class[consul::run_service]']) }
   end
 
   context 'When joining consul to a wan cluster by a known URL' do

--- a/spec/defines/consul_check_spec.rb
+++ b/spec/defines/consul_check_spec.rb
@@ -19,7 +19,7 @@ describe 'consul::check' do
       'script' => 'true'
     }}
     it {
-      should contain_file("/etc/consul/check_my_check.json") \
+      should contain_file("/etc/consul/extras/check_my_check.json") \
         .with_content(/"id" *: *"my_check"/) \
         .with_content(/"name" *: *"my_check"/) \
         .with_content(/"check" *: *\{/) \
@@ -34,7 +34,7 @@ describe 'consul::check' do
       'service_id' => 'my_service'
     }}
     it {
-      should contain_file("/etc/consul/check_my_check.json") \
+      should contain_file("/etc/consul/extras/check_my_check.json") \
         .with_content(/"id" *: *"my_check"/) \
         .with_content(/"name" *: *"my_check"/) \
         .with_content(/"check" *: *\{/) \
@@ -50,7 +50,7 @@ describe 'consul::check' do
       'token'    => 'too-cool-for-this-script'
     }}
     it {
-      should contain_file("/etc/consul/check_my_check.json") \
+      should contain_file("/etc/consul/extras/check_my_check.json") \
         .with_content(/"id" *: *"my_check"/) \
         .with_content(/"name" *: *"my_check"/) \
         .with_content(/"interval" *: *"30s"/) \
@@ -65,7 +65,7 @@ describe 'consul::check' do
       'http' => 'localhost'
     }}
     it {
-      should contain_file("/etc/consul/check_my_check.json") \
+      should contain_file("/etc/consul/extras/check_my_check.json") \
         .with_content(/"id" *: *"my_check"/) \
         .with_content(/"name" *: *"my_check"/) \
         .with_content(/"check" *: *\{/) \
@@ -80,7 +80,7 @@ describe 'consul::check' do
       'service_id' => 'my_service'
     }}
     it {
-      should contain_file("/etc/consul/check_my_check.json") \
+      should contain_file("/etc/consul/extras/check_my_check.json") \
         .with_content(/"id" *: *"my_check"/) \
         .with_content(/"name" *: *"my_check"/) \
         .with_content(/"check" *: *\{/) \
@@ -96,7 +96,7 @@ describe 'consul::check' do
       'token'    => 'too-cool-for-this-http'
     }}
     it {
-      should contain_file("/etc/consul/check_my_check.json") \
+      should contain_file("/etc/consul/extras/check_my_check.json") \
         .with_content(/"id" *: *"my_check"/) \
         .with_content(/"name" *: *"my_check"/) \
         .with_content(/"interval" *: *"30s"/) \
@@ -111,7 +111,7 @@ describe 'consul::check' do
       'http' => 'localhost'
     }}
     it {
-      should contain_file("/etc/consul/check_my_check.json") \
+      should contain_file("/etc/consul/extras/check_my_check.json") \
         .without_content(/"service_id"/) \
         .without_content(/"notes"/)
     }
@@ -121,7 +121,7 @@ describe 'consul::check' do
       'ttl' => '30s',
     }}
     it {
-      should contain_file("/etc/consul/check_my_check.json") \
+      should contain_file("/etc/consul/extras/check_my_check.json") \
         .with_content(/"id" *: *"my_check"/) \
         .with_content(/"name" *: *"my_check"/) \
         .with_content(/"check" *: *\{/) \
@@ -134,7 +134,7 @@ describe 'consul::check' do
       'service_id' => 'my_service'
     }}
     it {
-      should contain_file("/etc/consul/check_my_check.json") \
+      should contain_file("/etc/consul/extras/check_my_check.json") \
         .with_content(/"id" *: *"my_check"/) \
         .with_content(/"name" *: *"my_check"/) \
         .with_content(/"check" *: *\{/) \
@@ -148,7 +148,7 @@ describe 'consul::check' do
       'token' => 'too-cool-for-this-ttl'
     }}
     it {
-      should contain_file("/etc/consul/check_my_check.json") \
+      should contain_file("/etc/consul/extras/check_my_check.json") \
         .with_content(/"id" *: *"my_check"/) \
         .with_content(/"name" *: *"my_check"/) \
         .with_content(/"ttl" *: *"30s"/) \
@@ -162,7 +162,7 @@ describe 'consul::check' do
       'interval' => '30s',
     }}
     it {
-      should contain_file("/etc/consul/check_my_check.json") \
+      should contain_file("/etc/consul/extras/check_my_check.json") \
         .with_content(/"id" *: *"my_check"/) \
         .with_content(/"name" *: *"my_check"/) \
         .with_content(/"check" *: *\{/) \
@@ -177,7 +177,7 @@ describe 'consul::check' do
       'service_id' => 'my_service'
     }}
     it {
-      should contain_file("/etc/consul/check_my_check.json") \
+      should contain_file("/etc/consul/extras/check_my_check.json") \
         .with_content(/"id" *: *"my_check"/) \
         .with_content(/"name" *: *"my_check"/) \
         .with_content(/"check" *: *\{/) \
@@ -193,7 +193,7 @@ describe 'consul::check' do
       'token'    => 'too-cool-for-this-script'
     }}
     it {
-      should contain_file("/etc/consul/check_my_check.json") \
+      should contain_file("/etc/consul/extras/check_my_check.json") \
         .with_content(/"id" *: *"my_check"/) \
         .with_content(/"name" *: *"my_check"/) \
         .with_content(/"tcp" *: *"localhost:80"/) \
@@ -281,7 +281,7 @@ describe 'consul::check' do
       'service_id' => 'my_service',
       'id' => 'aa/bb',
     }}
-    it { should contain_file("/etc/consul/check_aa_bb.json") \
+    it { should contain_file("/etc/consul/extras/check_aa_bb.json") \
         .with_content(/"id" *: *"aa\/bb"/)
     }
   end
@@ -291,7 +291,7 @@ describe 'consul::check' do
       'service_id' => 'my_service',
       'id' => 'aa/bb/cc',
     }}
-    it { should contain_file("/etc/consul/check_aa_bb_cc.json") \
+    it { should contain_file("/etc/consul/extras/check_aa_bb_cc.json") \
         .with_content(/"id" *: *"aa\/bb\/cc"/)
     }
   end

--- a/spec/defines/consul_service_spec.rb
+++ b/spec/defines/consul_service_spec.rb
@@ -8,7 +8,7 @@ describe 'consul::service' do
     let(:params) {{}}
 
     it {
-      should contain_file("/etc/consul/service_my_service.json") \
+      should contain_file("/etc/consul/extras/service_my_service.json") \
         .with_content(/"service" *: *\{/) \
         .with_content(/"id" *: *"my_service"/) \
         .with_content(/"name" *: *"my_service"/)
@@ -19,13 +19,13 @@ describe 'consul::service' do
       'ensure' => 'absent',
     }}
     it {
-      should contain_file("/etc/consul/service_my_service.json") \
+      should contain_file("/etc/consul/extras/service_my_service.json") \
         .with('ensure' => 'absent')
     }
   end
   describe 'notify reload service' do
     it {
-      should contain_file("/etc/consul/service_my_service.json") \
+      should contain_file("/etc/consul/extras/service_my_service.json") \
         .that_notifies('Class[consul::reload_service]')
     }
   end
@@ -35,7 +35,7 @@ describe 'consul::service' do
     }}
 
     it {
-      should contain_file("/etc/consul/service_my_service.json") \
+      should contain_file("/etc/consul/extras/service_my_service.json") \
         .with_content(/"service" *: *\{/) \
         .with_content(/"id" *: *"my_service"/) \
         .with_content(/"name" *: *"different_name"/)
@@ -48,7 +48,7 @@ describe 'consul::service' do
     }}
 
     it {
-      should contain_file("/etc/consul/service_my_service.json") \
+      should contain_file("/etc/consul/extras/service_my_service.json") \
         .with_content(/"service" *: *\{/) \
         .with_content(/"id" *: *"my_service"/) \
         .with_content(/"name" *: *"different_name"/) \
@@ -65,7 +65,7 @@ describe 'consul::service' do
       ]
     }}
     it {
-      should contain_file("/etc/consul/service_my_service.json") \
+      should contain_file("/etc/consul/extras/service_my_service.json") \
         .with_content(/"checks" *: *\[/) \
         .with_content(/"interval" *: *"30s"/) \
         .with_content(/"script" *: *"true"/)
@@ -81,7 +81,7 @@ describe 'consul::service' do
       ]
     }}
     it {
-      should contain_file("/etc/consul/service_my_service.json") \
+      should contain_file("/etc/consul/extras/service_my_service.json") \
         .with_content(/"checks" *: *\[/) \
         .with_content(/"interval" *: *"30s"/) \
         .with_content(/"http" *: *"localhost"/)
@@ -96,7 +96,7 @@ describe 'consul::service' do
       ]
     }}
     it {
-      should contain_file("/etc/consul/service_my_service.json") \
+      should contain_file("/etc/consul/extras/service_my_service.json") \
         .with_content(/"checks" *: *\[/) \
         .with_content(/"ttl" *: *"30s"/)
     }
@@ -126,11 +126,11 @@ describe 'consul::service' do
       'port' => 5,
     }}
     it {
-      should contain_file("/etc/consul/service_my_service.json") \
+      should contain_file("/etc/consul/extras/service_my_service.json") \
         .with_content(/"port":5/)
     }
     it {
-      should_not contain_file("/etc/consul/service_my_service.json") \
+      should_not contain_file("/etc/consul/extras/service_my_service.json") \
         .with_content(/"port":"5"/)
     }
   end
@@ -177,7 +177,7 @@ describe 'consul::service' do
       ]
     }}
     it {
-      should contain_file("/etc/consul/service_my_service.json") \
+      should contain_file("/etc/consul/extras/service_my_service.json") \
         .with_content(/"checks" *: *\[/) \
         .with_content(/"interval" *: *"30s"/) \
         .with_content(/"script" *: *"true"/) \
@@ -189,7 +189,7 @@ describe 'consul::service' do
     let(:params) {{
       'id' => 'aa/bb',
     }}
-    it { should contain_file("/etc/consul/service_aa_bb.json") \
+    it { should contain_file("/etc/consul/extras/service_aa_bb.json") \
         .with_content(/"id" *: *"aa\/bb"/)
     }
   end
@@ -197,7 +197,7 @@ describe 'consul::service' do
     let(:params) {{
       'id' => 'aa/bb/cc',
     }}
-    it { should contain_file("/etc/consul/service_aa_bb_cc.json") \
+    it { should contain_file("/etc/consul/extras/service_aa_bb_cc.json") \
         .with_content(/"id" *: *"aa\/bb\/cc"/)
     }
   end
@@ -226,7 +226,7 @@ describe 'consul::service' do
     }}
 
     it {
-      should contain_file("/etc/consul/service_my_service.json") \
+      should contain_file("/etc/consul/extras/service_my_service.json") \
         .with_content(/"token" *: *"too-cool-for-this-service"/)
     }
   end

--- a/spec/defines/consul_watch_spec.rb
+++ b/spec/defines/consul_watch_spec.rb
@@ -14,7 +14,7 @@ describe 'consul::watch' do
       }}
       it {
         expect {
-          should contain_file('/etc/consul/watch_my_watch.json')
+          should contain_file('/etc/consul/extras/watch_my_watch.json')
         }.to raise_error(Puppet::Error, /Watches are only supported in Consul 0.4.0 and above/)
       }
     end
@@ -27,7 +27,7 @@ describe 'consul::watch' do
         'handler' => 'handler_path',
       }}
       it {
-        should contain_file('/etc/consul/watch_my_watch.json')
+        should contain_file('/etc/consul/extras/watch_my_watch.json')
       }
     end
 
@@ -39,7 +39,7 @@ describe 'consul::watch' do
         'handler' => 'handler_path',
       }}
       it {
-        should contain_file('/etc/consul/watch_my_watch.json')
+        should contain_file('/etc/consul/extras/watch_my_watch.json')
       }
     end
   end
@@ -76,7 +76,7 @@ describe 'consul::watch' do
       'handler' => 'handler_path',
     }}
     it {
-      should contain_file('/etc/consul/watch_my_watch.json') \
+      should contain_file('/etc/consul/extras/watch_my_watch.json') \
           .with_content(/"handler" *: *"handler_path"/) \
           .with_content(/"type" *: *"nodes"/)
     }
@@ -91,7 +91,7 @@ describe 'consul::watch' do
       'token' => 'tokenValue',
     }}
     it {
-      should contain_file('/etc/consul/watch_my_watch.json') \
+      should contain_file('/etc/consul/extras/watch_my_watch.json') \
           .with_content(/"datacenter" *: *"dcName"/) \
           .with_content(/"token" *: *"tokenValue"/)
     }
@@ -116,7 +116,7 @@ describe 'consul::watch' do
           'key'     => 'KeyName',
         }}
         it {
-          should contain_file('/etc/consul/watch_my_watch.json') \
+          should contain_file('/etc/consul/extras/watch_my_watch.json') \
             .with_content(/"type" *: *"key"/) \
             .with_content(/"key" *: *"KeyName"/)
         }
@@ -142,7 +142,7 @@ describe 'consul::watch' do
           'keyprefix' => 'keyPref',
         }}
         it {
-          should contain_file('/etc/consul/watch_my_watch.json') \
+          should contain_file('/etc/consul/extras/watch_my_watch.json') \
             .with_content(/"type" *: *"keyprefix"/) \
             .with_content(/"prefix" *: *"keyPref"/)
         }
@@ -168,7 +168,7 @@ describe 'consul::watch' do
           'service'   => 'serviceName',
         }}
         it {
-          should contain_file('/etc/consul/watch_my_watch.json') \
+          should contain_file('/etc/consul/extras/watch_my_watch.json') \
             .with_content(/"type" *: *"service"/) \
             .with_content(/"service" *: *"serviceName"/)
         }
@@ -184,7 +184,7 @@ describe 'consul::watch' do
           'passingonly' => true
         }}
         it {
-          should contain_file('/etc/consul/watch_my_watch.json') \
+          should contain_file('/etc/consul/extras/watch_my_watch.json') \
             .with_content(/"tag" *: *"serviceTagName"/) \
             .with_content(/"passingonly" *: *true/)
         }
@@ -198,7 +198,7 @@ describe 'consul::watch' do
           'handler'   => 'handler_path',
         }}
         it {
-          should contain_file('/etc/consul/watch_my_watch.json') \
+          should contain_file('/etc/consul/extras/watch_my_watch.json') \
             .with_content(/"type" *: *"checks"/)
         }
       end
@@ -212,7 +212,7 @@ describe 'consul::watch' do
           'state'   => 'serviceState',
         }}
         it {
-          should contain_file('/etc/consul/watch_my_watch.json') \
+          should contain_file('/etc/consul/extras/watch_my_watch.json') \
             .with_content(/"service" *: *"serviceName"/) \
             .with_content(/"state" *: *"serviceState"/)
         }
@@ -226,7 +226,7 @@ describe 'consul::watch' do
           'handler'   => 'handler_path',
         }}
         it {
-          should contain_file('/etc/consul/watch_my_watch.json') \
+          should contain_file('/etc/consul/extras/watch_my_watch.json') \
             .with_content(/"type" *: *"event"/)
         }
       end
@@ -239,7 +239,7 @@ describe 'consul::watch' do
           'event_name'=> 'eventName',
         }}
         it {
-          should contain_file('/etc/consul/watch_my_watch.json') \
+          should contain_file('/etc/consul/extras/watch_my_watch.json') \
             .with_content(/"name" *: *"eventName"/)
         }
       end
@@ -251,7 +251,7 @@ describe 'consul::watch' do
         'handler' => 'handler_path'
       }}
       it {
-        should contain_file('/etc/consul/watch_my_watch.json') \
+        should contain_file('/etc/consul/extras/watch_my_watch.json') \
             .with_content(/"type" *: *"nodes"/)
       }
     end
@@ -262,7 +262,7 @@ describe 'consul::watch' do
         'handler' => 'handler_path'
       }}
       it {
-        should contain_file('/etc/consul/watch_my_watch.json') \
+        should contain_file('/etc/consul/extras/watch_my_watch.json') \
             .with_content(/"type" *: *"services"/)
       }
     end
@@ -285,7 +285,7 @@ describe 'consul::watch' do
       'handler' => 'handler_path',
     }}
     it {
-      should contain_file('/etc/consul/watch_my_watch.json') \
+      should contain_file('/etc/consul/extras/watch_my_watch.json') \
           .that_notifies("Class[consul::reload_service]") \
     }
   end

--- a/templates/consul.debian.erb
+++ b/templates/consul.debian.erb
@@ -18,7 +18,7 @@ DESC="Consul service discovery framework"
 NAME=consul
 DAEMON=<%= scope.lookupvar('consul::bin_dir') %>/$NAME
 PIDFILE=/var/run/$NAME/$NAME.pid
-DAEMON_ARGS="agent -config-dir <%= scope.lookupvar('consul::config_dir') %> <%= scope.lookupvar('consul::extra_options') %>"
+DAEMON_ARGS="agent -config-dir <%= scope.lookupvar('consul::config_dir') %> -config-dir <%= scope.lookupvar('consul::config_dir') %>/extras <%= scope.lookupvar('consul::extra_options') %>"
 USER=<%= scope.lookupvar('consul::user') %>
 SCRIPTNAME=/etc/init.d/$NAME
 RPC_ADDR=-rpc-addr=<%= scope.lookupvar('consul::rpc_addr') %>:<%= scope.lookupvar('consul::rpc_port') %>

--- a/templates/consul.launchd.erb
+++ b/templates/consul.launchd.erb
@@ -18,6 +18,8 @@
             <string>agent</string>
             <string>-config-dir</string>
             <string><%= scope.lookupvar('consul::config_dir') %></string>
+            <string>-config-dir</string>
+            <string><%= scope.lookupvar('consul::config_dir') %>/extras</string>
 <% require 'shellwords' %>
 <% for extra_option in Shellwords.split(scope.lookupvar('consul::extra_options')) %>
             <string><%= extra_option %></string>

--- a/templates/consul.sles.erb
+++ b/templates/consul.sles.erb
@@ -36,7 +36,7 @@ case "$1" in
         echo -n "Starting consul "
         ## Start daemon with startproc(8). If this fails
         ## the return value is set appropriately by startproc.
-        startproc $CONSUL_BIN agent -config-dir "$CONFIG_DIR" <%= scope.lookupvar('consul::extra_options') %> >> "$LOG_FILE"
+        startproc $CONSUL_BIN agent -config-dir "$CONFIG_DIR" -config-dir "$CONFIG_DIR/extras" <%= scope.lookupvar('consul::extra_options') %> >> "$LOG_FILE"
 
         # Remember status and be verbose
         rc_status -v

--- a/templates/consul.systemd.erb
+++ b/templates/consul.systemd.erb
@@ -7,7 +7,7 @@ After=basic.target network.target
 User=<%= scope.lookupvar('consul::user') %>
 Group=<%= scope.lookupvar('consul::group') %>
 ExecStart=<%= scope.lookupvar('consul::bin_dir') %>/consul agent \
-  -config-dir <%= scope.lookupvar('consul::config_dir') %> <%= scope.lookupvar('consul::extra_options') %>
+  -config-dir <%= scope.lookupvar('consul::config_dir') %> -config-dir <%= scope.lookupvar('consul::config_dir') %>/extras <%= scope.lookupvar('consul::extra_options') %>
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=on-failure

--- a/templates/consul.sysv.erb
+++ b/templates/consul.sysv.erb
@@ -54,7 +54,7 @@ start() {
         [ -f $PID_FILE ] && rm $PID_FILE
         daemon --user=<%= scope.lookupvar('consul::user') %> \
             --pidfile="$PID_FILE" \
-            "$CONSUL" agent -pid-file "${PID_FILE}" -config-dir "$CONFIG" <%= scope.lookupvar('consul::extra_options') %> >> "$LOG_FILE" &
+            "$CONSUL" agent -pid-file "${PID_FILE}" -config-dir "$CONFIG" -config-dir "$CONFIG/extras" <%= scope.lookupvar('consul::extra_options') %> >> "$LOG_FILE" &
         retcode=$?
         touch /var/lock/subsys/consul
         return $retcode

--- a/templates/consul.upstart.erb
+++ b/templates/consul.upstart.erb
@@ -25,7 +25,7 @@ script
     [ -e $DEFAULTS ] && . $DEFAULTS
 
     export GOMAXPROCS=${GOMAXPROCS:-2}
-    exec start-stop-daemon -c $USER -g $GROUP -p $PID_FILE -x $CONSUL -S -- agent -config-dir $CONFIG -pid-file $PID_FILE <%= scope.lookupvar('consul::extra_options') %>
+    exec start-stop-daemon -c $USER -g $GROUP -p $PID_FILE -x $CONSUL -S -- agent -config-dir $CONFIG -config-dir $CONFIG/extras -pid-file $PID_FILE <%= scope.lookupvar('consul::extra_options') %>
 end script
 
 pre-stop script


### PR DESCRIPTION
Without this change, a purge cleaning up old services/watches will trigger a full service restart.
